### PR TITLE
Add PPO agent

### DIFF
--- a/agents/ppo_agent.py
+++ b/agents/ppo_agent.py
@@ -1,0 +1,202 @@
+import argparse
+from typing import List
+
+from gym_duckietown import simulator
+from gym_duckietown.envs.multimap_env import MultiMapEnv
+from gym_duckietown.wrappers import PyTorchObsWrapper, SteeringToWheelVelWrapper, DiscreteWrapper
+import ray
+from ray.tune.registry import register_env
+from ray.rllib.agents.ppo import PPOTrainer
+from ray.rllib.models import ModelCatalog
+from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
+import torch
+from torch import nn
+
+
+class ImageCritic(nn.Module):
+    def __init__(self):
+        """CNN that does the predictions.
+        Data from is as follows:
+
+                           > agent(x) -> a (R^256)
+                          /
+            x -> common(x)
+                         |
+                         L> critic(x) -> c (R)
+
+        The reason for sharing common part is because images are large so that many Conv's is quite expensive.
+        Also predicting value of a state and predicting next action to take is quite similar, and many papers use this approach.
+        """
+        super(self.__class__, self).__init__()
+        self.common = nn.Sequential(
+            nn.Conv2d(3, 8, 3),
+            nn.Conv2d(8, 16, 3),
+            nn.Conv2d(16, 32, 3),
+            nn.MaxPool2d(2),
+            nn.ReLU(),
+            nn.Conv2d(32, 32, 3),
+            nn.MaxPool2d(2),
+            nn.ReLU(),
+            nn.Conv2d(32, 32, 3),
+            nn.MaxPool2d(2),
+            nn.ReLU(),
+            nn.Conv2d(32, 32, 3),
+            nn.MaxPool2d(2),
+            nn.ReLU(),
+            nn.Conv2d(32, 32, 3),
+            nn.MaxPool2d(2),
+            nn.ReLU(),
+            nn.Conv2d(32, 32, 3),
+            nn.MaxPool2d(2),
+            nn.ReLU(),
+            nn.Conv2d(32, 32, 3),
+            nn.MaxPool2d(2),
+            nn.ReLU(),
+            nn.Flatten(),
+        )
+        self.critic = nn.Sequential(
+            nn.Linear(64, 64),
+            nn.ReLU(),
+            nn.Linear(64, 1),
+        )
+        self.agent = nn.Sequential(
+            nn.Linear(64, 64),
+            nn.ReLU(),
+            nn.Linear(64, 3),
+        )
+
+    def forward(self, x):
+        x = x.transpose(3, 1).float()
+        x = self.common(x)
+        a = self.agent(x)
+        v = self.critic(x)
+        return a, v
+
+
+class RLLibPPOCritic(TorchModelV2, nn.Module):
+    """
+    This is basically a wraper around ImageCritic that satisfies requirements of rllib.
+    """
+
+    def __init__(self, obs_space, action_space, num_outputs, model_config, name):
+        TorchModelV2.__init__(self, obs_space, action_space, num_outputs, model_config, name)
+        nn.Module.__init__(self)
+
+        self.base_model = ImageCritic()
+        self._value = None
+
+    def forward(self, input_dict, state, seq_lens):
+        # Structure of this forward is due to TorchModelV2.
+        # Note that we do not immediately return value, but rather save it for `value_function`
+        model_out, self._value = self.base_model(input_dict["obs"])
+        return model_out, state
+
+    def value_function(self):
+        return self._value
+
+
+def train_model(args):
+    # We are using custom model and environment, which need to be registered in ray/rllib
+    # Names can be anything.
+    register_env("DuckieTown-MultiMap", lambda _: DiscreteWrapper(MultiMapEnv()))
+
+    # Define trainer. Apart from env, config/framework and config/model, which are common among trainers.
+    trainer = PPOTrainer(
+        env="DuckieTown-MultiMap",
+        config={
+            "framework": "torch",
+            "model": {
+                "custom_model": "image-ppo",
+            },
+            "sgd_minibatch_size": 64,
+            "output": None,
+            "compress_observations": True,
+            "num_workers": 0,
+        }
+    )
+
+    for i in range(args.epochs):  # Number of episodes (basically epochs)
+        print(f'----------------------- Starting epoch {i} ----------------------- ')
+        # train() trains only a single episode
+        result = trainer.train()
+        print(result)
+
+        # Save model so far.
+        checkpoint_path = trainer.save()
+        print(f'Epoch {i}, checkpoint saved at: {checkpoint_path}')
+
+        # Cleanup CUDA memory to reduce memory usage.
+        torch.cuda.empty_cache()
+        # Debug log to monitor memory.
+        print(torch.cuda.memory_summary(device=None, abbreviated=False))
+
+
+def evaluate_model(args):
+    if args.model_path == '':
+        print('Cannot evaluate model, no --model_path set')
+        exit(1)
+
+    def get_env():
+        # Simulator env uses a single map, so better for evaluation/testing.
+        # DiscreteWrapper just converts wheel velocities to high level discrete actions.
+        return DiscreteWrapper(simulator.Simulator(
+            map_name=args.map,
+            max_steps=2000,
+        ))
+
+    # Rather than reuse the env, another one is created later because I can't
+    # figure out how to provide register_env with an object, th
+    # register_env('DuckieTown-Simulator', lambda _: get_env())
+    trainer = PPOTrainer(
+        env="DuckieTown-Simulator",
+        config={
+            "framework": "torch",
+            "model": {
+                "custom_model": "image-ppo",
+            },
+        },
+    )
+    trainer.restore(args.model_path)
+
+    sim_env = get_env()
+
+    # Standard OpenAI Gym reset/action/step/render loop.
+    # This matches how the `enjoy_reinforcement.py` script works, see: https://git.io/J3js2
+    done = False
+    observation = sim_env.reset()
+    episode_reward = 0
+    while not done:
+        action = trainer.compute_action(observation)
+        observation, reward, done, _ = sim_env.step(action)
+        episode_reward += reward
+        sim_env.render()
+
+    print(f'Episode complete, total reward: {episode_reward}')
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+
+    # Training options
+    parser.add_argument('--epochs', default=10, type=int, help='Num of epochs to train for')
+
+    # Evaluation options
+    parser.add_argument('--eval', action='store_true', default=False, help='Evaluate model instead of train')
+    parser.add_argument('--map', default='loop_empty', help='Which map to evaluate on, see https://git.io/J3jES')
+    # Looks like, e.g. `DQN_DuckieTown-MultiMap_2021-05-10_20-43-32ndgfiq44/checkpoint_000009/checkpoint-9`
+    parser.add_argument('--model_path', default='', help='Location to pre-trained model')
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = get_parser()
+
+    # Start ray
+    ray.init()
+    ModelCatalog.register_custom_model("image-ppo", RLLibPPOCritic)
+
+    if args.eval:
+        evaluate_model(args)
+    else:
+        train_model(args)

--- a/experiments/cartpole_ppo.py
+++ b/experiments/cartpole_ppo.py
@@ -1,0 +1,77 @@
+import ray
+from ray.rllib.agents.ppo import PPOTrainer
+from ray.rllib.models import ModelCatalog
+from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
+from torch import nn
+
+
+class ImageCritic(nn.Module):
+    def __init__(self):
+        super(self.__class__, self).__init__()
+        self.common = nn.Sequential(
+            nn.Linear(4, 16),
+            nn.ReLU(),
+            nn.Linear(16, 16),
+            nn.ReLU(),
+            nn.Linear(16, 32),
+            nn.ReLU(),
+            nn.Linear(32, 32),
+            nn.ReLU(),
+            nn.Linear(32, 64),
+            nn.ReLU(),
+        )
+        self.critic = nn.Sequential(
+            nn.Linear(64, 64),
+            nn.ReLU(),
+            nn.Linear(64, 1),
+        )
+        self.agent = nn.Sequential(
+            nn.Linear(64, 64),
+            nn.ReLU(),
+            nn.Linear(64, 2),
+        )
+
+    def forward(self, x):
+        x = x.float()
+        x = self.common(x)
+        a = self.agent(x)
+        v = self.critic(x)
+        return a, v
+
+
+class RLLibPPOCritic(TorchModelV2, nn.Module):
+    def __init__(self, obs_space, action_space, num_outputs, model_config, name):
+        TorchModelV2.__init__(self, obs_space, action_space, num_outputs, model_config, name)
+        nn.Module.__init__(self)
+
+        self.base_model = ImageCritic()
+        self._value = None
+
+    def forward(self, input_dict, state, seq_lens):
+        # Structure of this forward is due to TorchModelV2.
+        # Note that we do not immediately return value, but rather save it for `value_function`
+        model_out, self._value = self.base_model(input_dict["obs"])
+        # l = np.array([last_r])
+        # if l.shape == (1,):
+        #     l = l.reshape((1, 1))
+        return model_out, state
+
+    def value_function(self):
+        print(self._value.shape)
+        return self._value
+
+
+ModelCatalog.register_custom_model("image-ppo", RLLibPPOCritic)
+
+ray.init()
+trainer = PPOTrainer(
+    env="CartPole-v0",
+    config={
+        "framework": "torch",
+        "model": {
+            "custom_model": "image-ppo",
+        },
+    }
+)
+
+trainer.train()


### PR DESCRIPTION
Copy/paste from DQN agent but changes the rllib trainer. Unfortunately I am messing something up with the CNN shape I think because I can't get this model to train. The only thing I changed in the CNN was the shape of the actor output from 256 to 3. See error below.

I also tried creating a simplified version of the PPO trainer to use on the CartPole env for sanity checking, but getting the same error with that. Can be run with `python experiments/cartpole_ppo.py`.

```
INFO:gym-duckietown:using DuckietownEnv
2021-05-12 11:38:28,975	WARNING deprecation.py:33 -- DeprecationWarning: `framestack` has been deprecated. Use `num_framestacks (int)` instead. This will raise an error in the future!
Traceback (most recent call last):
  File "agents/ppo_agent.py", line 202, in <module>
    train_model(args)
  File "agents/ppo_agent.py", line 104, in train_model
    trainer = PPOTrainer(
  File "/Users/keyan/Envs/project2_dropouts/lib/python3.8/site-packages/ray/rllib/agents/trainer_template.py", line 107, in __init__
    Trainer.__init__(self, config, env, logger_creator)
  File "/Users/keyan/Envs/project2_dropouts/lib/python3.8/site-packages/ray/rllib/agents/trainer.py", line 486, in __init__
    super().__init__(config, logger_creator)
  File "/Users/keyan/Envs/project2_dropouts/lib/python3.8/site-packages/ray/tune/trainable.py", line 97, in __init__
    self.setup(copy.deepcopy(self.config))
  File "/Users/keyan/Envs/project2_dropouts/lib/python3.8/site-packages/ray/rllib/agents/trainer.py", line 654, in setup
    self._init(self.config, self.env_creator)
  File "/Users/keyan/Envs/project2_dropouts/lib/python3.8/site-packages/ray/rllib/agents/trainer_template.py", line 134, in _init
    self.workers = self._make_workers(
  File "/Users/keyan/Envs/project2_dropouts/lib/python3.8/site-packages/ray/rllib/agents/trainer.py", line 725, in _make_workers
    return WorkerSet(
  File "/Users/keyan/Envs/project2_dropouts/lib/python3.8/site-packages/ray/rllib/evaluation/worker_set.py", line 90, in __init__
    self._local_worker = self._make_worker(
  File "/Users/keyan/Envs/project2_dropouts/lib/python3.8/site-packages/ray/rllib/evaluation/worker_set.py", line 321, in _make_worker
    worker = cls(
  File "/Users/keyan/Envs/project2_dropouts/lib/python3.8/site-packages/ray/rllib/evaluation/rollout_worker.py", line 479, in __init__
    self.policy_map, self.preprocessors = self._build_policy_map(
  File "/Users/keyan/Envs/project2_dropouts/lib/python3.8/site-packages/ray/rllib/evaluation/rollout_worker.py", line 1111, in _build_policy_map
    policy_map[name] = cls(obs_space, act_space, merged_conf)
  File "/Users/keyan/Envs/project2_dropouts/lib/python3.8/site-packages/ray/rllib/policy/policy_template.py", line 266, in __init__
    self._initialize_loss_from_dummy_batch(
  File "/Users/keyan/Envs/project2_dropouts/lib/python3.8/site-packages/ray/rllib/policy/policy.py", line 634, in _initialize_loss_from_dummy_batch
    postprocessed_batch = self.postprocess_trajectory(batch_for_postproc)
  File "/Users/keyan/Envs/project2_dropouts/lib/python3.8/site-packages/ray/rllib/policy/policy_template.py", line 290, in postprocess_trajectory
    return postprocess_fn(self, sample_batch,
  File "/Users/keyan/Envs/project2_dropouts/lib/python3.8/site-packages/ray/rllib/evaluation/postprocessing.py", line 138, in compute_gae_for_sample_batch
    batch = compute_advantages(
  File "/Users/keyan/Envs/project2_dropouts/lib/python3.8/site-packages/ray/rllib/evaluation/postprocessing.py", line 49, in compute_advantages
    vpred_t = np.concatenate(
  File "<__array_function__ internals>", line 5, in concatenate
ValueError: all the input arrays must have same number of dimensions, but the array at index 0 has 2 dimension(s) and the array at index 1 has 1 dimension(s)
```