### PR TITLE
Update DDPG to match eval/flags pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,4 @@
 mypy:
 	mypy --ignore-missing-imports --follow-imports=skip examples/
+clean:
+	find . -name *.out -or -name *.log -or -name *.swp -or -name *.swo -or -name .DS_Store -or -name .swp -or -name *.pyc | xargs -n 1 rm

--- a/examples/continous_ddpg.py
+++ b/examples/continous_ddpg.py
@@ -1,3 +1,5 @@
+import argparse
+
 from gym_duckietown.envs.multimap_env import MultiMapEnv
 from gym_duckietown.envs.duckietown_env import DuckietownLF
 from gym_duckietown.wrappers import PyTorchObsWrapper, SteeringToWheelVelWrapper, DiscreteWrapper
@@ -74,7 +76,7 @@ class ImageCritic(nn.Module):
         return a * 2 - 1, v
 
 
-class RLLibDQNCritic(TorchModelV2, nn.Module):
+class RLLibDDPGCritic(TorchModelV2, nn.Module):
     def __init__(self, obs_space, action_space, num_outputs, model_config, name):
         TorchModelV2.__init__(self, obs_space, action_space, num_outputs, model_config, name)
         nn.Module.__init__(self)
@@ -89,30 +91,114 @@ class RLLibDQNCritic(TorchModelV2, nn.Module):
     def value_function(self):
         return self._value
 
-# Start ray
-ray.init()
 
-# We are using custom model and environment, which need to be registered in ray/rllib
-# Names can be anything.
-# NOTE: We are using DuckietownLF environment because SteeringToWheelVelWrapper does not cooperate with multimap.
-ModelCatalog.register_custom_model("image-dqn", RLLibDQNCritic)
-register_env("DuckieTown-MultiMap", lambda _: SteeringToWheelVelWrapper(DuckietownLF()))
+def train_model(args):
+    register_env("DuckieTown-MultiMap", lambda _: SteeringToWheelVelWrapper(DuckietownLF()))
 
-# Define trainer. Apart from env, config/framework and config/model, which are common among trainers.
-# Here is a list of default config keys/values: https://docs.ray.io/en/master/rllib-training.html#common-parameters
-# For DDPG specifically there are also additionally these keys: https://docs.ray.io/en/master/rllib-algorithms.html#ddpg
-trainer = DDPGTrainer(
-    env="DuckieTown-MultiMap",
-    config={
-        "framework": "torch",
-        "model": {
-            "custom_model": "image-dqn",
+   # Define trainer. Apart from env, config/framework and config/model, which are common among trainers.
+   # Here is a list of default config keys/values:
+   #    https://docs.ray.io/en/master/rllib-training.html#common-parameters
+   # For DDPG specifically there are also additionally these keys:
+   #    https://docs.ray.io/en/master/rllib-algorithms.html#ddpg
+    trainer = DDPGTrainer(
+        env="DuckieTown-MultiMap",
+        config={
+            "framework": "torch",
+            "model": {
+                "custom_model": "image-ddpg",
+            },
+            "learning_starts": 0,
+        }
+    )
+
+    # Start training from a checkpoint, if available.
+    if args.model_path:
+        trainer.restore(args.model_path)
+
+    for i in range(args.epochs):  # Number of episodes (basically epochs)
+        print(f'----------------------- Starting epoch {i} ----------------------- ')
+        # train() trains only a single episode
+        result = trainer.train()
+        print(result)
+
+        # Save model so far.
+        checkpoint_path = trainer.save()
+        print(f'Epoch {i}, checkpoint saved at: {checkpoint_path}')
+
+        # Cleanup CUDA memory to reduce memory usage.
+        torch.cuda.empty_cache()
+        # Debug log to monitor memory.
+        print(torch.cuda.memory_summary(device=None, abbreviated=False))
+
+
+def evaluate_model(args):
+    if args.model_path == '':
+        print('Cannot evaluate model, no --model_path set')
+        exit(1)
+
+    def get_env():
+        # Simulator env uses a single map, so better for evaluation/testing.
+        # return SteeringToWheelVelWrapper(DuckietownLF(
+        # ))
+        return SteeringToWheelVelWrapper(simulator.Simulator(
+            map_name=args.map,
+            max_steps=2000,
+        ))
+
+    # Rather than reuse the env, another one is created later because I can't
+    # figure out how to provide register_env with an object, th
+    register_env('DuckieTown-Simulator', lambda _: get_env())
+    trainer = DQNTrainer(
+        env="DuckieTown-Simulator",
+        config={
+            "framework": "torch",
+            "model": {
+                "custom_model": "image-ddpg",
+            },
         },
-        "learning_starts": 0,
-        # "record_env": True,  # Doing this allows us to record images from the DuckieTown Gym! Might be useful for report.
-    }
-)
+    )
+    trainer.restore(args.model_path)
 
-for _ in trange(10):  # Number of epochs
-    result = trainer.train()
-    print(result)
+    sim_env = get_env()
+
+    # Standard OpenAI Gym reset/action/step/render loop.
+    # This matches how the `enjoy_reinforcement.py` script works, see: https://git.io/J3js2
+    done = False
+    observation = sim_env.reset()
+    episode_reward = 0
+    while not done:
+        action = trainer.compute_action(observation)
+        observation, reward, done, _ = sim_env.step(action)
+        episode_reward += reward
+        sim_env.render()
+
+    print(f'Episode complete, total reward: {episode_reward}')
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+
+    # Training options
+    parser.add_argument('--epochs', default=10, type=int, help='Num of epochs to train for')
+
+    # Evaluation options
+    parser.add_argument('--eval', action='store_true', default=False, help='Evaluate model instead of train')
+    parser.add_argument('--map', default='loop_empty', help='Which map to evaluate on, see https://git.io/J3jES')
+    # Looks like, e.g. `DQN_DuckieTown-MultiMap_2021-05-10_20-43-32ndgfiq44/checkpoint_000009/checkpoint-9`
+    parser.add_argument('--model_path', default='', help='Location to pre-trained model')
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = get_parser()
+
+    # Start ray
+    ray.init()
+    # NOTE: We are using DuckietownLF environment because SteeringToWheelVelWrapper does not cooperate with multimap.
+    ModelCatalog.register_custom_model("image-ddpg", RLLibDDPGCritic)
+
+    if args.eval:
+        evaluate_model(args)
+    else:
+        train_model(args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ frozendict==2.0.2
 future==0.18.2
 gast==0.3.3
 gltflib==1.0.8
+google==3.0.0
 google-api-core==1.26.3
 google-auth==1.30.0
 google-auth-oauthlib==0.4.4
@@ -78,7 +79,7 @@ opt-einsum==3.3.0
 oyaml==1.0
 packaging==20.9
 pandas==1.2.4
-Pillow==8.1.1
+Pillow==7.2.0
 plotly==4.14.3
 prometheus-client==0.10.1
 protobuf==3.16.0
@@ -127,6 +128,7 @@ termcolor==1.1.0
 tifffile==2021.4.8
 torch==1.8.1
 torchvision==0.9.1
+tqdm==4.60.0
 trimesh==3.9.15
 typed-ast==1.4.3
 typing-extensions==3.7.4.3


### PR DESCRIPTION
- Changes DDPG model to match the pattern used in DQN to allow flags for training/evaluation/etc
- Downgrades Pillow back to 7.2.0, `gym` still needs the old version, this is fixed in `master` but the new release hasn't been published to pypi yet (see: https://github.com/openai/gym/issues/2199)

I trained this on Colab for 21 epochs and unfortunately it performs worse than the DQN model. So next step is to try tuning configuration for it.

Reward performance after 21st epoch was:
```
'episode_reward_max': -951.2575697449776
'episode_reward_min': -1115.6132074538282
'episode_reward_mean': -1030.4857112883233
```