### PR TITLE
Add Plotter() and instrument all models

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ wget https://raw.githubusercontent.com/duckietown/gym-duckietown/daffy/src/gym_d
 ## Checking setup
 If everything got installed properly
 ```
-python examples/discrete_dqn.py
+python -m examples.discrete_dqn
 ```
 
 If you also installed tensorboard running:
@@ -62,11 +62,21 @@ The notebook is also accessible here: https://colab.research.google.com/drive/1F
 
 ## Evaluation
 
-We don't yet have graphing and support for quantitative evaluation. Evaluation should be done locally if you are rendering the simulator, though you can add support to ignore rendering for cloud evaluation.
+### Training
+
+Each agent/model logs the results for each epoch of training using a `plotter.Plotter()` object. At the end of a training run there is a plot saved to the directory which you executed from.
+
+You can also manually generate a plot from just the saved reward history data by running:
+```
+python plotter.py <path_to_file.txt>
+```
+
+### Model Evaluation
+Evaluation should be done locally if you are rendering the simulator, though you can add support to ignore rendering for cloud evaluation.
 
 To evaluate a trained model (only DQN supported right now) look at the available flags:
 ```
-$ python examples/discrete_dqn.py -h
+$ python -m examples.discrete_dqn -h
 
 usage: discrete_dqn.py [-h] [--eval] [--epochs EPOCHS] [--model_path MODEL_PATH] [--map MAP]
 
@@ -81,7 +91,7 @@ optional arguments:
 
 For example we can train on the default map using the provided baseline model with:
 ```
-$ python examples/discrete_dqn.py --eval --model_path trained_models/dqn_v0/model
+$ python -m examples.discrete_dqn --eval --model_path trained_models/dqn_v0/model
 ```
 
 The baseline model is terrible, you should see it go around in circles slowly.

--- a/agents/ppo_agent.py
+++ b/agents/ppo_agent.py
@@ -12,6 +12,8 @@ from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
 import torch
 from torch import nn
 
+import plotter
+
 
 class ImageCritic(nn.Module):
     def __init__(self):
@@ -116,11 +118,17 @@ def train_model(args):
         }
     )
 
+    # Start training from a checkpoint, if available.
+    if args.model_path:
+        trainer.restore(args.model_path)
+
+    plot = plotter.Plotter('ppo_agent')
     for i in range(args.epochs):  # Number of episodes (basically epochs)
         print(f'----------------------- Starting epoch {i} ----------------------- ')
         # train() trains only a single episode
         result = trainer.train()
         print(result)
+        plot.add_results(result)
 
         # Save model so far.
         checkpoint_path = trainer.save()
@@ -130,6 +138,8 @@ def train_model(args):
         torch.cuda.empty_cache()
         # Debug log to monitor memory.
         print(torch.cuda.memory_summary(device=None, abbreviated=False))
+
+    plot.plot('PPO DuckieTown-MultiMap')
 
 
 def evaluate_model(args):

--- a/examples/continous_ddpg.py
+++ b/examples/continous_ddpg.py
@@ -12,6 +12,8 @@ import torch
 from torch import nn
 from tqdm import trange
 
+import plotter
+
 
 class ImageCritic(nn.Module):
     def __init__(self):
@@ -115,11 +117,13 @@ def train_model(args):
     if args.model_path:
         trainer.restore(args.model_path)
 
+    plot = plotter.Plotter('ddpg_agent')
     for i in range(args.epochs):  # Number of episodes (basically epochs)
         print(f'----------------------- Starting epoch {i} ----------------------- ')
         # train() trains only a single episode
         result = trainer.train()
         print(result)
+        plot.add_results(result)
 
         # Save model so far.
         checkpoint_path = trainer.save()
@@ -129,6 +133,8 @@ def train_model(args):
         torch.cuda.empty_cache()
         # Debug log to monitor memory.
         print(torch.cuda.memory_summary(device=None, abbreviated=False))
+
+    plot.plot('DDPG DuckieTown-MultiMap')
 
 
 def evaluate_model(args):

--- a/examples/discrete_dqn.py
+++ b/examples/discrete_dqn.py
@@ -12,6 +12,8 @@ from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
 import torch
 from torch import nn
 
+import plotter
+
 
 class ImageCritic(nn.Module):
     def __init__(self):
@@ -126,11 +128,13 @@ def train_model(args):
     if args.model_path:
         trainer.restore(args.model_path)
 
+    plot = plotter.Plotter('dqn_agent')
     for i in range(args.epochs):  # Number of episodes (basically epochs)
         print(f'----------------------- Starting epoch {i} ----------------------- ')
         # train() trains only a single episode
         result = trainer.train()
         print(result)
+        plot.add_results(result)
 
         # Save model so far.
         checkpoint_path = trainer.save()
@@ -140,6 +144,8 @@ def train_model(args):
         torch.cuda.empty_cache()
         # Debug log to monitor memory.
         print(torch.cuda.memory_summary(device=None, abbreviated=False))
+
+    plot.plot('DQN DuckieTown-MultiMap')
 
 
 def evaluate_model(args):

--- a/experiments/cartpole_ppo.py
+++ b/experiments/cartpole_ppo.py
@@ -4,6 +4,8 @@ from ray.rllib.models import ModelCatalog
 from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
 from torch import nn
 
+import plotter
+
 
 class ImageCritic(nn.Module):
     def __init__(self):
@@ -35,7 +37,7 @@ class ImageCritic(nn.Module):
         x = x.float()
         x = self.common(x)
         a = self.agent(x)
-        v = self.critic(x)
+        v = self.critic(x).view(-1)
         return a, v
 
 
@@ -57,7 +59,6 @@ class RLLibPPOCritic(TorchModelV2, nn.Module):
         return model_out, state
 
     def value_function(self):
-        print(self._value.shape)
         return self._value
 
 
@@ -74,4 +75,9 @@ trainer = PPOTrainer(
     }
 )
 
-trainer.train()
+plot = plotter.Plotter('ppo_cartpole')
+for epoch in range(10):
+    results = trainer.train()
+    plot.add_results(results)
+
+plot.plot(title='PPO CartPole-v0')

--- a/plotter.py
+++ b/plotter.py
@@ -1,0 +1,71 @@
+import sys
+from typing import Any, Dict, Optional
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+import pandas as pd
+import numpy as np
+
+
+class Plotter:
+    def __init__(self, experiment_name: str = 'foo', prior_file: Optional[str] = None):
+        if prior_file is not None:
+            self.data_filename = prior_file
+            self.plot_filename = 'your_plot'
+        else:
+            self.plot_filename = f'{experiment_name}_plot'
+            self.data_filename = f'{experiment_name}_plot_data.txt'
+
+        self.data_file = open(self.data_filename, 'a')
+
+    def add_results(self, results: Dict[str, Any]) -> None:
+        log_line = f"{results['training_iteration']},{results['episode_reward_mean']}\n"
+        self.data_file.write(log_line)
+        # In case training crashes, keep writing data out.
+        self.data_file.flush()
+
+    def plot(self, title: Optional[str] = None) -> None:
+        self.data_file.close()
+        with open(self.data_filename, 'r') as f:
+            data = [x.split(',') for x in f.read().splitlines()]
+            data = [[int(x[0]), float(x[1])] for x in data]
+        df = pd.DataFrame(data)
+        plot_data(df, title=title, plot_name=self.plot_filename)
+
+
+def plot_data(data, xaxis=0, value=1, smooth=1, plot_name='your_plot', title=None):
+    """
+    Adapted from: https://git.io/JsYa0
+    """
+    if smooth > 1:
+        y = np.ones(smooth)
+        for datum in data:
+            x = np.asarray(datum[value])
+            z = np.ones(len(x))
+            smoothed_x = np.convolve(x,y,'same') / np.convolve(z,y,'same')
+            datum[value] = smoothed_x
+
+    if isinstance(data, list):
+        data = pd.concat(data, ignore_index=True)
+    sns.set(style="darkgrid", font_scale=1.5)
+
+    sns.lineplot(data=data, x=xaxis, y=value, ci='sd')
+
+    xscale = np.max(np.asarray(data[xaxis])) > 5e3
+    if xscale:
+        # Just some formatting niceness: x-axis scale in scientific notation if max x is large
+        plt.ticklabel_format(style='sci', axis='x', scilimits=(0,0))
+
+    plt.tight_layout(pad=0.5)
+    plt.xlabel('Epochs')
+    plt.ylabel('Mean Reward')
+
+    if title is not None:
+        plt.title(title)
+
+    plt.savefig(plot_name, bbox_inches='tight')
+
+
+if __name__ == '__main__':
+    plot = Plotter(prior_file=sys.argv[1])
+    plot.plot(title='PPO CartPole-v0')

--- a/requirements.txt
+++ b/requirements.txt
@@ -113,6 +113,7 @@ retrying==1.3.3
 rsa==4.7.2
 scikit-image==0.18.1
 scipy==1.6.3
+seaborn==0.11.1
 six==1.15.0
 soupsieve==2.2.1
 stringcase==1.2.0


### PR DESCRIPTION
Adds a useful helper class that you use during training to get a graph of results. For example, this is the resulting graph from running: `python -m experiments.cartpole_ppo`:

![your_plot](https://user-images.githubusercontent.com/6401746/118213374-aa101300-b422-11eb-93db-5ea6ad0e810a.png)


Note that because of how Python imports are annoying, you have to call into the training modules differently using the `-m` flag, I updated this in the README too.